### PR TITLE
Fixed missing mdtraj.utils.six error

### DIFF
--- a/bgmol/tpl/hdf5.py
+++ b/bgmol/tpl/hdf5.py
@@ -27,12 +27,6 @@ import numpy as np
 from mdtraj import version
 from mdtraj.core.topology import _topology_from_subset, Topology
 from mdtraj.utils import unitcell
-# from mdtraj.utils.six import PY3  doesn't exist anymore since mdtraj 1.10.0
-# this is what it does:
-PY3 = sys.version_info[0] == 3
-if PY3:
-    basestring = str
-# is Python 2 support still neccesary?
 import mdtraj.core.element as elem
 from mdtraj.utils import in_units_of, ensure_type, import_, cast_indices
 from mdtraj.utils.six import string_types
@@ -1030,7 +1024,7 @@ class HDF5Reporter(object):
                  temperature=True, velocities=False, forces=False, atomSubset=None):
         """Create a HDF5Reporter.
         """
-        if isinstance(file, basestring):
+        if isinstance(file, str):
             self._traj_file = self.backend(file, 'w')
         elif isinstance(file, self.backend):
             self._traj_file = file

--- a/bgmol/tpl/hdf5.py
+++ b/bgmol/tpl/hdf5.py
@@ -27,9 +27,12 @@ import numpy as np
 from mdtraj import version
 from mdtraj.core.topology import _topology_from_subset, Topology
 from mdtraj.utils import unitcell
-from mdtraj.utils.six import PY3
+# from mdtraj.utils.six import PY3  doesn't exist anymore since mdtraj 1.10.0
+# this is what it does:
+PY3 = sys.version_info[0] == 3
 if PY3:
     basestring = str
+# is Python 2 support still neccesary?
 import mdtraj.core.element as elem
 from mdtraj.utils import in_units_of, ensure_type, import_, cast_indices
 from mdtraj.utils.six import string_types

--- a/bgmol/tpl/hdf5.py
+++ b/bgmol/tpl/hdf5.py
@@ -29,7 +29,6 @@ from mdtraj.core.topology import _topology_from_subset, Topology
 from mdtraj.utils import unitcell
 import mdtraj.core.element as elem
 from mdtraj.utils import in_units_of, ensure_type, import_, cast_indices
-from mdtraj.utils.six import string_types
 from ..util.importing import import_openmm
 
 try:
@@ -91,7 +90,7 @@ def load_hdf5(filename, stride=None, atom_indices=None, frame=None):
     --------
     mdtraj.HDF5TrajectoryFile :  Low level interface to HDF5 files
     """
-    if not isinstance(filename, string_types):
+    if not isinstance(filename, str):
         raise TypeError('filename must be of type string for load_lh5. '
             'you supplied %s' % type(filename))
 


### PR DESCRIPTION
## Description
Since mdtraj 1.10.0, `mdtraj.utils.six`, a module that supports dealing with Python 2 an Python 3, doesn't exist anymore. I fixed this dependency.

## Questions
- [ ] Is Python 2 support still necessary?
